### PR TITLE
Support TypeScript v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "all": true
   },
   "dependencies": {
-    "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0"
+    "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",


### PR DESCRIPTION
Since typescript 5.0 is already [released](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/), it should be a good idea to update this package's dependencies list. 